### PR TITLE
Updated and simplified INSTALL.md

### DIFF
--- a/docs/imager/install.md
+++ b/docs/imager/install.md
@@ -6,8 +6,8 @@ Pretty easy method.
 
 Download & Extract:
 ```shell
-$ http --follow https://github.com/imager-io/imager/releases/download/imager-0.3.3/imager-v0.3.3-apple.tar.gz > imager-v0.3.3-apple.tar.gz
-$ tar -xvzf imager-v0.3.3-apple.tar.gz
+$ http --follow https://github.com/imager-io/imager/releases/download/imager-0.3.4/imager-v0.3.4-apple.tar.gz > imager-v0.3.4-apple.tar.gz
+$ tar -xvzf imager.tar.gz
 ```
 Verify:
 ```
@@ -18,8 +18,8 @@ $ ./apple/bin/imager --help
 
 Download & Extract:
 ```shell
-$ http --follow https://github.com/imager-io/imager/releases/download/imager-0.3.3/imager-v0.3.3-linux.tar.gz > imager-v0.3.3-linux.tar.gz
-$ tar -xvzf imager-v0.3.3-linux.tar.gz
+$ wget https://github.com/imager-io/imager/releases/download/imager-0.3.4/imager-v0.3.4-apple.tar.gz
+$ tar -xvzf imager.tar.gz
 ```
 
 Verify:


### PR DESCRIPTION
- Updated the download links to the 0.3.4 command. Temporally resolve #7. 
- Replaced the http command to wget. I don’t know what it is, and since I don’t know if it is preinstalled on mac, I haven’t modified that one.
- Simplified the tar extract command, so it extracts any downloaded imager builds, regardless of the downloaded version.